### PR TITLE
Provide Logion PSP34 SmartContract 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+members = [
+    "contracts/**",
+]
+resolver = "2"
+exclude = [
+]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Logion Smart Contract library for Ink!
 
 ## Development setup
 
-Refer to Astar Docs [ink! environment]() for details.
+Refer to Astar Docs [ink! environment](https://docs.astar.network/docs/build/environment/ink_environment) for details.
 
 In a nutshell, for Ubuntu:
 
@@ -44,12 +44,10 @@ cargo build contract --release
 * Sign
 
 ### Manual, with polkadot.js
+A similar procedure is available on Polkadot-JS:
 * Use [polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.shibuya.astar.network#/contracts) to connect to Shibuya.
-* Click "Upload & deploy code" and select `logion_psp34.contract` under `target/ink/logion_psp34`.
-* Click "Next".
-* Provide a value for `nonce`, `collectionLocId` and `certHost`.
-* Click "Deploy".
-* Sign
+* Click "Developers > Contracts" to access a UI similar to Contract UI.
+* Follow the same steps.
 
 **WARNING** On 8/9/2023 attempt, this method did not succeed to deploy.
 

--- a/README.md
+++ b/README.md
@@ -70,4 +70,5 @@ In order to use a contract that someone else deployed, you need to know the **Co
 |------------|--------------------------------------------------------------------------------------------|-------------------------------------------------|
 | 2023-09-06 | https://contracts-ui.substrate.io/contract/XyNVZ92vFrYf4rCj8EoAXMRWRG7okRy7gxhn167HaYQZqTc | XyNVZ92vFrYf4rCj8EoAXMRWRG7okRy7gxhn167HaYQZqTc |
 | 2023-09-08 | https://contracts-ui.substrate.io/contract/ZEoCdLf7zXHNw2BEtzL6mptzHKKFWAc2jYyeuRkVQUW7ddw | ZEoCdLf7zXHNw2BEtzL6mptzHKKFWAc2jYyeuRkVQUW7ddw |
+| 2023-09-08 | https://contracts-ui.substrate.io/contract/ai7fX8imUNnUaJfPxQMHhGagp9Bx7YGKxF3Xdnoe7tcUXbU | ai7fX8imUNnUaJfPxQMHhGagp9Bx7YGKxF3Xdnoe7tcUXbU |
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,73 @@
 # logion-ink
 Logion Smart Contract library for Ink!
+
+## Development setup
+
+Refer to Astar Docs [ink! environment]() for details.
+
+In a nutshell, for Ubuntu:
+
+```shell
+cargo install cargo-dylint dylint-link
+cargo install cargo-contract --force --locked
+```
+
+## Test
+
+```shell
+cd contracts/logion_psp34
+cargo test
+```
+
+## Build
+
+```shell
+cd contracts/logion_psp34
+cargo build contract --release
+```
+
+## Deploy
+
+### Prerequisite
+* Get some SHY to your Polkadot account with the [Shibuya faucet](https://portal.astar.network/shibuya-testnet/assets).
+
+### Manual, with Contract UI
+* Go to [Contract UI](https://contracts-ui.substrate.io/?rpc=wss://rpc.shibuya.astar.network) and connect to Astar Shibuya.
+* Click "Add New Contract".
+* Click "Upload New Contract".
+* Choose an Account with enough SHY.
+* Choose a Contract Name.
+* Under "Upload Contract Bundle" select `logion_psp34.contract` under `target/ink/logion_psp34`.
+* Provide a value for `nonce`, `collectionLocId` and `certHost`.
+* Click "Next" and review the summary.
+* Click "Upload and Instantiate".
+* Sign
+
+### Manual, with polkadot.js
+* Use [polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.shibuya.astar.network#/contracts) to connect to Shibuya.
+* Click "Upload & deploy code" and select `logion_psp34.contract` under `target/ink/logion_psp34`.
+* Click "Next".
+* Provide a value for `nonce`, `collectionLocId` and `certHost`.
+* Click "Deploy".
+* Sign
+
+**WARNING** On 8/9/2023 attempt, this method did not succeed to deploy.
+
+## Use a Contract
+
+In order to use a contract that someone else deployed, you need to know the **Contract Address** and the **ABI metadata** (json):
+
+* Go to [Contract UI](https://contracts-ui.substrate.io/?rpc=wss://rpc.shibuya.astar.network) and connect to Astar Shibuya.
+* Click "Add New Contract".
+* Click "Use On-Chain Contract Address".
+* Provide the Contract Address, Name
+* Click "Upload Metadata" and select `logion_psp34.json` under `target/ink/logion_psp34`.
+* Click "Add Contract".
+
+
+## Deployment Log
+| Date       | URL                                                                                        | Contract Address                                |
+|------------|--------------------------------------------------------------------------------------------|-------------------------------------------------|
+| 2023-09-06 | https://contracts-ui.substrate.io/contract/XyNVZ92vFrYf4rCj8EoAXMRWRG7okRy7gxhn167HaYQZqTc | XyNVZ92vFrYf4rCj8EoAXMRWRG7okRy7gxhn167HaYQZqTc |
+| 2023-09-08 | https://contracts-ui.substrate.io/contract/ZEoCdLf7zXHNw2BEtzL6mptzHKKFWAc2jYyeuRkVQUW7ddw | ZEoCdLf7zXHNw2BEtzL6mptzHKKFWAc2jYyeuRkVQUW7ddw |
+

--- a/contracts/logion_psp34/Cargo.toml
+++ b/contracts/logion_psp34/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "logion_psp34"
+version = "1.0.0"
+edition = "2021"
+authors = ["Logion Team <team@logion.network>"]
+
+[dependencies]
+
+ink = { version = "4.2.1", default-features = false }
+ink_env = { version = "4.2.1", default-features = false }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
+openbrush = { tag = "4.0.0-beta", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = ["psp34", "ownable"] }
+
+[lib]
+name = "logion_psp34"
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "ink_env/std",
+    "scale/std",
+    "scale-info/std",
+    "openbrush/std",
+]
+ink-as-dependency = []

--- a/contracts/logion_psp34/lib.rs
+++ b/contracts/logion_psp34/lib.rs
@@ -7,6 +7,7 @@ pub mod tests;
 #[openbrush::contract]
 pub mod logion_psp34 {
     use core::fmt::{Display, Error, Formatter};
+    use core::str::FromStr;
     use ink_env::format;
     use ink_env::hash::Sha2x256;
     use openbrush::traits::Storage;
@@ -42,19 +43,20 @@ pub mod logion_psp34 {
 
     impl LogionPsp34 {
         #[ink(constructor)]
-        pub fn new(nonce: String, collection_loc_id: String, cert_host: String) -> Self {
+        pub fn new(nonce: String, collection_loc_id: u128, cert_host: String) -> Self {
             let mut instance = Self::default();
 
             metadata::Internal::_set_attribute(&mut instance, ID_FOR_LOGION_METADATA.clone(), String::from(NONCE_KEY), nonce);
-            metadata::Internal::_set_attribute(&mut instance, ID_FOR_LOGION_METADATA.clone(), String::from(COLLECTION_LOC_ID_KEY), collection_loc_id);
+            metadata::Internal::_set_attribute(&mut instance, ID_FOR_LOGION_METADATA.clone(), String::from(COLLECTION_LOC_ID_KEY), format!("{}", collection_loc_id));
             metadata::Internal::_set_attribute(&mut instance, ID_FOR_LOGION_METADATA.clone(), String::from(CERT_HOST_KEY), cert_host);
 
             instance
         }
 
         #[ink(message)]
-        pub fn get_collection_loc_id(&self) -> String {
-            self.get_logion_metadata(COLLECTION_LOC_ID_KEY)
+        pub fn get_collection_loc_id(&self) -> u128 {
+            let collection_loc_id = self.get_logion_metadata(COLLECTION_LOC_ID_KEY);
+            u128::from_str(&collection_loc_id).unwrap()
         }
 
         #[ink(message)]

--- a/contracts/logion_psp34/lib.rs
+++ b/contracts/logion_psp34/lib.rs
@@ -1,0 +1,120 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[cfg(test)]
+pub mod tests;
+
+#[openbrush::implementation(PSP34, PSP34Mintable, PSP34Metadata)]
+#[openbrush::contract]
+pub mod logion_psp34 {
+    use core::fmt::{Display, Error, Formatter};
+    use ink_env::format;
+    use ink_env::hash::Sha2x256;
+    use openbrush::traits::Storage;
+
+    const ID_FOR_LOGION_METADATA: &Id = &Id::U8(1);
+    const NONCE_KEY: &'static str = "nonce";
+    const COLLECTION_LOC_ID_KEY: &'static str = "collection_loc_id";
+    const CERT_HOST_KEY: &'static str = "cert_host";
+
+    pub struct LogionHash {
+        value: Hash
+    }
+
+    impl Display for LogionHash {
+
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+            write!(f, "0x")?;
+            for i in self.value.as_ref() {
+                write!(f, "{:02x?}", i)?;
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
+    #[cfg_attr(feature = "std", derive(::scale_info::TypeInfo))]
+    pub enum LogionError {
+        /// Returned if some Logion Metadata is missing.
+        MissingLogionMetadata,
+    }
+
+    #[ink(storage)]
+    #[derive(Default, Storage)]
+    pub struct LogionPsp34 {
+        #[storage_field]
+        psp34: psp34::Data,
+        #[storage_field]
+        metadata: metadata::Data,
+    }
+
+    impl LogionPsp34 {
+        #[ink(constructor)]
+        pub fn new(nonce: String, collection_loc_id: String, cert_host: String) -> Self {
+            let mut instance = Self::default();
+
+            metadata::Internal::_set_attribute(&mut instance, ID_FOR_LOGION_METADATA.clone(), String::from(NONCE_KEY), nonce);
+            metadata::Internal::_set_attribute(&mut instance, ID_FOR_LOGION_METADATA.clone(), String::from(COLLECTION_LOC_ID_KEY), collection_loc_id);
+            metadata::Internal::_set_attribute(&mut instance, ID_FOR_LOGION_METADATA.clone(), String::from(CERT_HOST_KEY), cert_host);
+
+            instance
+        }
+
+        #[ink(message)]
+        pub fn get_collection_loc_id(&self) -> Result<String, LogionError> {
+            self.get_logion_metadata(COLLECTION_LOC_ID_KEY)
+        }
+
+        #[ink(message)]
+        pub fn get_item_id(&self, token_id: Id) -> Result<String, LogionError> {
+            let item_id_seed = self.get_item_id_seed(token_id)?;
+            let item_id = self.hash(&item_id_seed.as_bytes().to_vec());
+            Ok(format!("{}", item_id))
+        }
+
+        pub(crate) fn get_item_id_seed(&self, token_id: Id) -> Result<String, LogionError> {
+            let nonce = self.get_logion_metadata(NONCE_KEY)?;
+
+            let id_type = String::from(match token_id {
+                Id::U8(_) => "U8",
+                Id::U16(_) => "U16",
+                Id::U32(_) => "U32",
+                Id::U64(_) => "U64",
+                Id::U128(_) => "U128",
+                Id::Bytes(_) => "Bytes",
+            });
+
+            let id_value: String = match token_id {
+                Id::U8(value) => format!("{}", value),
+                Id::U16(value) => format!("{}", value),
+                Id::U32(value) => format!("{}", value),
+                Id::U64(value) => format!("{}", value),
+                Id::U128(value) => format!("{}", value),
+                Id::Bytes(value) => format!("{}", self.hash(&value)),
+            };
+
+            Ok(format!("{}:{}({})", nonce, id_type, id_value))
+        }
+
+        #[ink(message)]
+        pub fn get_certificate_url(&self, token_id: Id) -> Result<String, LogionError> {
+            let cert_host = self.get_logion_metadata(CERT_HOST_KEY)?;
+            let collection_loc_id = self.get_collection_loc_id()?;
+            let item_id = self.get_item_id(token_id)?;
+            let url = format!("https://{}/public/certificate/{}/{}", cert_host, collection_loc_id, item_id);
+            Ok(url)
+        }
+
+        fn hash(&self, input: &Vec<u8>) -> LogionHash {
+            let value = self.env().hash_bytes::<Sha2x256>(input);
+            LogionHash { value: value.into() }
+        }
+
+        fn get_logion_metadata(&self, key: &'static str) -> Result<String, LogionError> {
+            let attribute = PSP34MetadataImpl::get_attribute(self, ID_FOR_LOGION_METADATA.clone(), String::from(key));
+            match attribute {
+                Some(value) => Ok(value),
+                _ => Err(LogionError::MissingLogionMetadata)
+            }
+        }
+    }
+}

--- a/contracts/logion_psp34/tests.rs
+++ b/contracts/logion_psp34/tests.rs
@@ -1,0 +1,61 @@
+use ink::env::DefaultEnvironment;
+use ink::env::test::set_callee;
+use ink::primitives::{AccountId};
+use openbrush::contracts::psp34::Id;
+
+use crate::logion_psp34::LogionPsp34;
+
+const COLLECTION_LOC_ID: &str = "334801581596596632473758891935041239976";
+
+#[test]
+fn it_gets_collection_loc_id() {
+    set_up();
+    let contract = new_contract();
+    assert_eq!(contract.get_collection_loc_id(), Ok(COLLECTION_LOC_ID.to_string()));
+}
+
+#[test]
+fn it_gets_item_id_seed() {
+    set_up();
+    let contract = new_contract();
+    assert_eq!(contract.get_item_id_seed(Id::U8(123)), Ok("202210131727:U8(123)".to_string()));
+    assert_eq!(contract.get_item_id_seed(Id::U16(123)), Ok("202210131727:U16(123)".to_string()));
+    assert_eq!(contract.get_item_id_seed(Id::U32(123)), Ok("202210131727:U32(123)".to_string()));
+    assert_eq!(contract.get_item_id_seed(Id::U64(123)), Ok("202210131727:U64(123)".to_string()));
+    assert_eq!(contract.get_item_id_seed(Id::U128(123)), Ok("202210131727:U128(123)".to_string()));
+
+    let token_id: Vec<u8> = "abcd".into();
+    // echo -n "abcd" | sha256sum => 88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589
+    assert_eq!(contract.get_item_id_seed(Id::Bytes(token_id)), Ok("202210131727:Bytes(0x88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589)".to_string()));
+}
+
+#[test]
+fn it_gets_item_id() {
+    set_up();
+    let contract = new_contract();
+    let token_id = Id::U8(123);
+    // echo -n "202210131727:U8(123)" | sha256sum => 71e240ef02a005a86b70ad321687f95afb8c6519122962d9144e943cd04311cf
+    let expected_hash = "0x71e240ef02a005a86b70ad321687f95afb8c6519122962d9144e943cd04311cf".to_string();
+    assert_eq!(contract.get_item_id(token_id), Ok(expected_hash));
+}
+
+#[test]
+fn it_gets_certificate_url() {
+    set_up();
+    let contract = new_contract();
+    let token_id = Id::U8(123);
+    assert_eq!(contract.get_certificate_url(token_id), Ok("https://certificate.logion.network/public/certificate/334801581596596632473758891935041239976/0x71e240ef02a005a86b70ad321687f95afb8c6519122962d9144e943cd04311cf".to_string()));
+}
+
+fn new_contract() -> LogionPsp34 {
+    LogionPsp34::new(
+        "202210131727".to_string(),
+        COLLECTION_LOC_ID.to_string(),
+        "certificate.logion.network".to_string(),
+    )
+}
+
+fn set_up() {
+    let callee: AccountId = AccountId::from([0xFFu8; 32]);
+    set_callee::<DefaultEnvironment>(callee);
+}

--- a/contracts/logion_psp34/tests.rs
+++ b/contracts/logion_psp34/tests.rs
@@ -11,22 +11,22 @@ const COLLECTION_LOC_ID: &str = "334801581596596632473758891935041239976";
 fn it_gets_collection_loc_id() {
     set_up();
     let contract = new_contract();
-    assert_eq!(contract.get_collection_loc_id(), Ok(COLLECTION_LOC_ID.to_string()));
+    assert_eq!(contract.get_collection_loc_id(), COLLECTION_LOC_ID.to_string());
 }
 
 #[test]
 fn it_gets_item_id_seed() {
     set_up();
     let contract = new_contract();
-    assert_eq!(contract.get_item_id_seed(Id::U8(123)), Ok("202210131727:U8(123)".to_string()));
-    assert_eq!(contract.get_item_id_seed(Id::U16(123)), Ok("202210131727:U16(123)".to_string()));
-    assert_eq!(contract.get_item_id_seed(Id::U32(123)), Ok("202210131727:U32(123)".to_string()));
-    assert_eq!(contract.get_item_id_seed(Id::U64(123)), Ok("202210131727:U64(123)".to_string()));
-    assert_eq!(contract.get_item_id_seed(Id::U128(123)), Ok("202210131727:U128(123)".to_string()));
+    assert_eq!(contract.get_item_id_seed(Id::U8(123)), "202210131727:U8(123)".to_string());
+    assert_eq!(contract.get_item_id_seed(Id::U16(123)), "202210131727:U16(123)".to_string());
+    assert_eq!(contract.get_item_id_seed(Id::U32(123)), "202210131727:U32(123)".to_string());
+    assert_eq!(contract.get_item_id_seed(Id::U64(123)), "202210131727:U64(123)".to_string());
+    assert_eq!(contract.get_item_id_seed(Id::U128(123)), "202210131727:U128(123)".to_string());
 
     let token_id: Vec<u8> = "abcd".into();
     // echo -n "abcd" | sha256sum => 88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589
-    assert_eq!(contract.get_item_id_seed(Id::Bytes(token_id)), Ok("202210131727:Bytes(0x88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589)".to_string()));
+    assert_eq!(contract.get_item_id_seed(Id::Bytes(token_id)), "202210131727:Bytes(0x88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589)".to_string());
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn it_gets_item_id() {
     let token_id = Id::U8(123);
     // echo -n "202210131727:U8(123)" | sha256sum => 71e240ef02a005a86b70ad321687f95afb8c6519122962d9144e943cd04311cf
     let expected_hash = "0x71e240ef02a005a86b70ad321687f95afb8c6519122962d9144e943cd04311cf".to_string();
-    assert_eq!(contract.get_item_id(token_id), Ok(expected_hash));
+    assert_eq!(contract.get_item_id(token_id), expected_hash);
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn it_gets_certificate_url() {
     set_up();
     let contract = new_contract();
     let token_id = Id::U8(123);
-    assert_eq!(contract.get_certificate_url(token_id), Ok("https://certificate.logion.network/public/certificate/334801581596596632473758891935041239976/0x71e240ef02a005a86b70ad321687f95afb8c6519122962d9144e943cd04311cf".to_string()));
+    assert_eq!(contract.get_certificate_url(token_id), "https://certificate.logion.network/public/certificate/334801581596596632473758891935041239976/0x71e240ef02a005a86b70ad321687f95afb8c6519122962d9144e943cd04311cf".to_string());
 }
 
 fn new_contract() -> LogionPsp34 {

--- a/contracts/logion_psp34/tests.rs
+++ b/contracts/logion_psp34/tests.rs
@@ -5,13 +5,13 @@ use openbrush::contracts::psp34::Id;
 
 use crate::logion_psp34::LogionPsp34;
 
-const COLLECTION_LOC_ID: &str = "334801581596596632473758891935041239976";
+const COLLECTION_LOC_ID: u128 = 334801581596596632473758891935041239976;
 
 #[test]
 fn it_gets_collection_loc_id() {
     set_up();
     let contract = new_contract();
-    assert_eq!(contract.get_collection_loc_id(), COLLECTION_LOC_ID.to_string());
+    assert_eq!(contract.get_collection_loc_id(), COLLECTION_LOC_ID);
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn it_gets_certificate_url() {
 fn new_contract() -> LogionPsp34 {
     LogionPsp34::new(
         "202210131727".to_string(),
-        COLLECTION_LOC_ID.to_string(),
+        COLLECTION_LOC_ID,
         "certificate.logion.network".to_string(),
     )
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = [ "rustfmt", "rust-src" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"


### PR DESCRIPTION
* A basic SmartContract for Polkadot blockchains.
* Following the [PSP-34](https://github.com/w3f/PCPs/blob/master/PCPs/pcp-34.md) (now renamed to PCP-34...)
* Using ink! and OpenBrush

The following metadata are stored:
* Collection LOC ID.
* A `nonce` - ensure uniqueness of Item ID when different contract instances target the same Collection LOC.
* The hostname of the Logion Certificate URL (typically `certificate.logion.network`).

The following infos are exposed (via messages):
* Collection LOC ID.
* For a given NFT ID, the corresponding Logion Collection Item ID and its certificate URL.
___
This PR focuses on implementation. Packaging and reusability will be done in a subsequent PR.